### PR TITLE
Fix CVE-2026-0603: Second-Order SQL Injection in InlineIdsOrClauseBuilder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/IdsClauseBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/IdsClauseBuilder.java
@@ -122,6 +122,8 @@ public abstract class IdsClauseBuilder {
 				throw new IllegalArgumentException( e );
 			}
 		}
-		return String.valueOf( value );
+		throw new IllegalStateException(
+				"Cannot quote identifier value of non LiteralType: " + type.getName()
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/BigDecimalType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BigDecimalType.java
@@ -8,6 +8,7 @@ package org.hibernate.type;
 
 import java.math.BigDecimal;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.java.BigDecimalTypeDescriptor;
 import org.hibernate.type.descriptor.sql.NumericTypeDescriptor;
 
@@ -17,7 +18,7 @@ import org.hibernate.type.descriptor.sql.NumericTypeDescriptor;
  * @author Gavin King
  * @author Steve Ebersole
  */
-public class BigDecimalType extends AbstractSingleColumnStandardBasicType<BigDecimal> {
+public class BigDecimalType extends AbstractSingleColumnStandardBasicType<BigDecimal> implements LiteralType<BigDecimal> {
 	public static final BigDecimalType INSTANCE = new BigDecimalType();
 
 	public BigDecimalType() {
@@ -32,5 +33,10 @@ public class BigDecimalType extends AbstractSingleColumnStandardBasicType<BigDec
 	@Override
 	protected boolean registerUnderJavaType() {
 		return true;
+	}
+
+	@Override
+	public String objectToSQLString(BigDecimal value, Dialect dialect) throws Exception {
+		return toString( value );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/CharacterNCharType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CharacterNCharType.java
@@ -41,7 +41,7 @@ public class CharacterNCharType
 	}
 
 	public String objectToSQLString(Character value, Dialect dialect) {
-		return '\'' + toString( value ) + '\'';
+		return dialect.inlineLiteral( toString( value ) );
 	}
 
 	public Character stringToObject(String xml) {

--- a/hibernate-core/src/main/java/org/hibernate/type/CharacterType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CharacterType.java
@@ -46,7 +46,7 @@ public class CharacterType
 	}
 
 	public String objectToSQLString(Character value, Dialect dialect) {
-		return '\'' + toString( value ) + '\'';
+		return dialect.inlineLiteral( toString( value ) );
 	}
 
 	public Character stringToObject(String xml) {

--- a/hibernate-core/src/main/java/org/hibernate/type/CurrencyType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CurrencyType.java
@@ -38,6 +38,6 @@ public class CurrencyType
 	}
 
 	public String objectToSQLString(Currency value, Dialect dialect) throws Exception {
-		return "\'" + toString(  value ) + "\'";
+		return dialect.inlineLiteral( toString( value ) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
@@ -202,7 +202,7 @@ public class CustomType
 
 	@Override
 	public String objectToSQLString(Object value, Dialect dialect) throws Exception {
-		return ( (EnhancedUserType) getUserType() ).objectToSQLString( value);
+		return ( (EnhancedUserType) getUserType() ).objectToSQLString( value, dialect );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/NTextType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/NTextType.java
@@ -30,7 +30,7 @@ public class NTextType extends AbstractSingleColumnStandardBasicType<String> imp
 
 	@Override
 	public String objectToSQLString(String value, Dialect dialect) throws Exception {
-		return StringNVarcharType.INSTANCE.objectToSQLString( value, dialect );
+		return dialect.inlineLiteral( value );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/NTextType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/NTextType.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.type;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.java.StringTypeDescriptor;
 import org.hibernate.type.descriptor.sql.LongNVarcharTypeDescriptor;
 
@@ -16,7 +17,7 @@ import org.hibernate.type.descriptor.sql.LongNVarcharTypeDescriptor;
  * @author Bertrand Renuart
  * @author Steve Ebersole
  */
-public class NTextType extends AbstractSingleColumnStandardBasicType<String> {
+public class NTextType extends AbstractSingleColumnStandardBasicType<String> implements LiteralType<String> {
 	public static final NTextType INSTANCE = new NTextType();
 
 	public NTextType() {
@@ -25,6 +26,11 @@ public class NTextType extends AbstractSingleColumnStandardBasicType<String> {
 
 	public String getName() { 
 		return "ntext";
+	}
+
+	@Override
+	public String objectToSQLString(String value, Dialect dialect) throws Exception {
+		return StringNVarcharType.INSTANCE.objectToSQLString( value, dialect );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/StringNVarcharType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StringNVarcharType.java
@@ -36,7 +36,7 @@ public class StringNVarcharType
 	}
 
 	public String objectToSQLString(String value, Dialect dialect) throws Exception {
-		return '\'' + value + '\'';
+		return dialect.inlineLiteral( value );
 	}
 
 	public String stringToObject(String xml) throws Exception {

--- a/hibernate-core/src/main/java/org/hibernate/type/StringType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StringType.java
@@ -35,7 +35,7 @@ public class StringType
 	}
 
 	public String objectToSQLString(String value, Dialect dialect) throws Exception {
-		return '\'' + value + '\'';
+		return dialect.inlineLiteral( value );
 	}
 
 	public String stringToObject(String xml) throws Exception {

--- a/hibernate-core/src/main/java/org/hibernate/type/TextType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TextType.java
@@ -5,6 +5,8 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.type;
+
+import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.java.StringTypeDescriptor;
 import org.hibernate.type.descriptor.sql.LongVarcharTypeDescriptor;
 
@@ -15,7 +17,7 @@ import org.hibernate.type.descriptor.sql.LongVarcharTypeDescriptor;
  * @author Bertrand Renuart
  * @author Steve Ebersole
  */
-public class TextType extends AbstractSingleColumnStandardBasicType<String> {
+public class TextType extends AbstractSingleColumnStandardBasicType<String> implements LiteralType<String> {
 	public static final TextType INSTANCE = new TextType();
 
 	public TextType() {
@@ -24,6 +26,11 @@ public class TextType extends AbstractSingleColumnStandardBasicType<String> {
 
 	public String getName() { 
 		return "text";
+	}
+
+	@Override
+	public String objectToSQLString(String value, Dialect dialect) throws Exception {
+		return StringType.INSTANCE.objectToSQLString( value, dialect );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/TextType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TextType.java
@@ -24,13 +24,13 @@ public class TextType extends AbstractSingleColumnStandardBasicType<String> impl
 		super( LongVarcharTypeDescriptor.INSTANCE, StringTypeDescriptor.INSTANCE );
 	}
 
-	public String getName() { 
+	public String getName() {
 		return "text";
 	}
 
 	@Override
 	public String objectToSQLString(String value, Dialect dialect) throws Exception {
-		return StringType.INSTANCE.objectToSQLString( value, dialect );
+		return dialect.inlineLiteral( value );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/usertype/EnhancedUserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/EnhancedUserType.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.usertype;
 
+import org.hibernate.dialect.Dialect;
+
 /**
  * A custom type that may function as an identifier or discriminator type
  * 
@@ -13,9 +15,18 @@ package org.hibernate.usertype;
  */
 public interface EnhancedUserType extends UserType {
 	/**
-	 * Return an SQL literal representation of the value
+	 * Return an SQL literal representation of the value, as it should appear in a query.
+	 * If the value is quoted, the returned string should be escaped appropriately.
 	 */
 	String objectToSQLString(Object value);
+
+	/**
+	 * Return an SQL literal representation of the value, as it should appear in a query.
+	 * If the value is quoted, the returned string should be escaped appropriately.
+	 */
+	default String objectToSQLString(Object value, Dialect dialect) {
+		return objectToSQLString( value );
+	}
 	
 	/**
 	 * Return a string representation of this value, as it should appear in an XML document

--- a/hibernate-core/src/test/java/org/hibernate/test/bulkid/InlineStringIdsInClauseBulkIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bulkid/InlineStringIdsInClauseBulkIdTest.java
@@ -1,0 +1,205 @@
+package org.hibernate.test.bulkid;
+
+import java.sql.Statement;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.hql.spi.id.inline.InlineIdsInClauseBulkIdStrategy;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+
+@RequiresDialectFeature(DialectChecks.SupportRowValueConstructorSyntaxInInList.class)
+public class InlineStringIdsInClauseBulkIdTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Person.class, Doctor.class, Engineer.class
+		};
+	}
+
+	@Override
+	protected void configure(Configuration configuration) {
+		super.configure( configuration );
+		configuration.setProperty(
+				AvailableSettings.HQL_BULK_ID_STRATEGY,
+				InlineIdsInClauseBulkIdStrategy.class.getName()
+		);
+	}
+
+	@Override
+	protected boolean isCleanupTestDataRequired() {
+		return true;
+	}
+
+	@Override
+	protected boolean isCleanupTestDataUsingBulkDelete() {
+		return true;
+	}
+
+	@Before
+	public void setUp() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					session.doWork( connection -> {
+						final Statement statement = connection.createStatement();
+						statement.execute(
+								"insert into Person (employed, name, id) values (0, null, 'd0''')"
+						);
+						statement.execute(
+								"insert into Doctor (specialization, id) values ('spec_0', 'd0''')"
+						);
+						statement.close();
+						for ( int i = 1; i < 10; i++ ) {
+							Doctor doctor = new Doctor();
+							doctor.setId( "d" + i );
+							doctor.setEmployed( i % 2 );
+							doctor.setSpecialization( "spec_" + i );
+							session.persist( doctor );
+						}
+					} );
+				}
+		);
+		doInHibernate(
+				this::sessionFactory, session -> {
+					for ( int i = 0; i < 10; i++ ) {
+						Engineer engineer = new Engineer();
+						engineer.setId( "i" + i );
+						engineer.setEmployed( i % 2 );
+						engineer.setFellow( i % 2 );
+						session.persist( engineer );
+					}
+				}
+		);
+
+		doInHibernate(
+				this::sessionFactory, session -> {
+					final Long count = session.createQuery(
+									"select count(p) from Person p where employed = 1",
+									Long.class
+							)
+							.getSingleResult();
+					assertEquals( 10L, count.longValue() );
+				}
+		);
+	}
+
+	@Test
+	public void testUpdate() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					session.createQuery(
+									"update Person set fellow = :fellow, name = :name where employed = :employed"
+							).setParameter( "fellow", 0 )
+							.setParameter( "name", "John Doe" )
+							.setParameter( "employed", 0 )
+							.executeUpdate();
+					// 5 employed engineers updated to fellow = 0
+					long fellows = session.createQuery(
+							"select count(e) from Engineer e where fellow = 0",
+							Long.class
+					).getSingleResult();
+					assertEquals( 5L, fellows );
+					// 10 total employed persons updated to "John Doe"
+					long johnDoes = session.createQuery(
+							"select count(e) from Person e where name = 'John Doe'",
+							Long.class
+					).getSingleResult();
+					assertEquals( 10L, johnDoes );
+				}
+		);
+	}
+
+	@Test
+	public void testDeleteFromPerson() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					session.createQuery( "delete from Person where employed = :employed" )
+							.setParameter( "employed", 1 )
+							.executeUpdate();
+					long persons = session.createQuery( "select count (p) from Person p", Long.class ).getSingleResult();
+					assertEquals( 10L, persons );
+				}
+		);
+	}
+
+	@Test
+	public void testDeleteSingleDoctor() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					session.createQuery( "delete from Doctor where specialization = 'spec_0'" ).executeUpdate();
+					long doctors = session.createQuery( "select count (d) from Doctor d", Long.class ).getSingleResult();
+					assertEquals( 9L, doctors );
+				}
+		);
+	}
+
+	@Entity(name = "Person")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public static class Person {
+		@Id
+		private String id;
+		private String name;
+		private int employed;
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public int getEmployed() {
+			return employed;
+		}
+
+		public void setEmployed(int employed) {
+			this.employed = employed;
+		}
+	}
+
+	@Entity(name = "Doctor")
+	public static class Doctor extends Person {
+		private String specialization;
+
+		public String getSpecialization() {
+			return specialization;
+		}
+
+		public void setSpecialization(String specialization) {
+			this.specialization = specialization;
+		}
+	}
+
+	@Entity(name = "Engineer")
+	public static class Engineer extends Person {
+		private int fellow;
+
+		public int getFellow() {
+			return fellow;
+		}
+
+		public void setFellow(int fellow) {
+			this.fellow = fellow;
+		}
+	}
+}


### PR DESCRIPTION
### Vulnerability Description
A remote attacker with low privileges could exploit a second-order SQL injection vulnerability by:

Stage 1 — Persisting an entity with a malicious string ID containing unsanitized non-alphanumeric characters (e.g., SQL fragments with ', ;, etc.)
Stage 2 — When Hibernate later performs a bulk UPDATE or DELETE using InlineIdsOrClauseBuilder, the stored malicious ID is inlined directly into the generated SQL predicate without escaping, causing the injected SQL to execute
Exploitation conditions:

Application uses string-based primary keys (`@Id private String id`)
Application allows user-controlled values for those IDs (e.g., natural keys like usernames, product codes)
Hibernate uses the inline ID OR clause strategy for bulk operations
Impact: Sensitive information disclosure (including reading system files), unauthorized data manipulation or deletion, application-level denial of service.

### Root Cause & Fix
In [IdsClauseBuilder.quoteIdentifier()](https://github.com/atlassian/hibernate-orm/blob/5.6.15-atlassian-X/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/IdsClauseBuilder.java#L112-L125), the fallback path for non-LiteralType types returned `String.valueOf(value)` inlining the raw, unescaped value directly into SQL:

```java
// BEFORE (vulnerable)
return String.valueOf( value );

// AFTER (fixed)
throw new IllegalStateException(
    "Cannot quote identifier value of non LiteralType: " + type.getName()
);
```
Additionally, several string-based types that implement LiteralType were calling objectToSQLString() without dialect-aware escaping, and some types (TextType, NTextType, BigDecimalType) were not implementing LiteralType at all, causing them to fall through to the unsafe path.

### Tests
[test.zip](https://github.com/user-attachments/files/29012589/test.zip)

<img width="716" height="194" alt="Screenshot 2026-06-16 at 11 07 42 PM" src="https://github.com/user-attachments/assets/dec040aa-02c4-4750-b847-82a004d384af" />

<img width="927" height="488" alt="Screenshot 2026-06-16 at 11 10 27 PM" src="https://github.com/user-attachments/assets/fa44b110-a84c-4c5c-91d3-b0ed11d47427" />

